### PR TITLE
Make S3 bucket name for cleanup versions tests editable as a variable.

### DIFF
--- a/src/main/groovy/de/jansauer/elasticbeanstalk/ElasticBeanstalkExtension.groovy
+++ b/src/main/groovy/de/jansauer/elasticbeanstalk/ElasticBeanstalkExtension.groovy
@@ -5,11 +5,11 @@ import org.gradle.api.provider.Property
 
 class ElasticBeanstalkExtension {
 
-    final Property<String> applicationName
-    final Property<Integer> versionToPreserve
+  final Property<String> applicationName
+  final Property<Integer> versionToPreserve
 
-    ElasticBeanstalkExtension(Project project) {
-        applicationName = project.objects.property(String)
-        versionToPreserve = project.objects.property(Integer)
-    }
+  ElasticBeanstalkExtension(Project project) {
+    applicationName = project.objects.property(String)
+    versionToPreserve = project.objects.property(Integer)
+  }
 }

--- a/src/main/groovy/de/jansauer/elasticbeanstalk/ElasticBeanstalkPlugin.groovy
+++ b/src/main/groovy/de/jansauer/elasticbeanstalk/ElasticBeanstalkPlugin.groovy
@@ -5,11 +5,11 @@ import org.gradle.api.Project
 
 class ElasticBeanstalkPlugin implements Plugin<Project> {
 
-    void apply(Project target) {
-        def extension = target.extensions.create('elasticBeanstalk', ElasticBeanstalkExtension, target)
-        target.tasks.create('cleanupVersions', CleanupVersionsTask) {
-            applicationName = extension.applicationName
-            versionToPreserve = extension.versionToPreserve
-        }
+  void apply(Project target) {
+    def extension = target.extensions.create('elasticBeanstalk', ElasticBeanstalkExtension, target)
+    target.tasks.create('cleanupVersions', CleanupVersionsTask) {
+      applicationName = extension.applicationName
+      versionToPreserve = extension.versionToPreserve
     }
+  }
 }

--- a/src/test/groovy/de/jansauer/elasticbeanstalk/CleanupVersionsTest.groovy
+++ b/src/test/groovy/de/jansauer/elasticbeanstalk/CleanupVersionsTest.groovy
@@ -24,6 +24,9 @@ class CleanupVersionsTest extends Specification {
     @Shared
     AmazonS3 s3Client
 
+    @Shared
+    String s3BucketName
+
     @Rule
     final TemporaryFolder testProjectDir = new TemporaryFolder()
 
@@ -31,6 +34,7 @@ class CleanupVersionsTest extends Specification {
 
     def setupSpec() {
         applicationName = 'Gradle Plugin Test'
+        s3BucketName = 'elasticbeanstalk-eu-central-1-000354356830'
         s3Client = AmazonS3ClientBuilder.standard().withRegion('eu-central-1').build()
         client = AWSElasticBeanstalkClientBuilder.standard()
                 .withRegion('eu-central-1')
@@ -89,13 +93,13 @@ class CleanupVersionsTest extends Specification {
     }
 
     def createApplicationVersion(String version) {
-        s3Client.putObject('elasticbeanstalk-eu-central-1-000354356830', version + '.jar', version as String)
+        s3Client.putObject(s3BucketName, version + '.jar', version as String)
         client.createApplicationVersion(new CreateApplicationVersionRequest()
                 .withApplicationName(applicationName)
                 .withVersionLabel(version)
-                .withDescription("")
+                .withDescription("Test application version " + version)
                 .withSourceBundle(new S3Location()
-                .withS3Bucket('elasticbeanstalk-eu-central-1-000354356830')
+                .withS3Bucket(s3BucketName)
                 .withS3Key(version + '.jar'))
                 .withProcess(false));
     }

--- a/src/test/groovy/de/jansauer/elasticbeanstalk/CleanupVersionsTest.groovy
+++ b/src/test/groovy/de/jansauer/elasticbeanstalk/CleanupVersionsTest.groovy
@@ -15,48 +15,48 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class CleanupVersionsTest extends Specification {
 
-    @Shared
-    String applicationName
+  @Shared
+  String applicationName
 
-    @Shared
-    AWSElasticBeanstalk client
+  @Shared
+  AWSElasticBeanstalk client
 
-    @Shared
-    AmazonS3 s3Client
+  @Shared
+  AmazonS3 s3Client
 
-    @Shared
-    String s3BucketName
+  @Shared
+  String s3BucketName
 
-    @Rule
-    final TemporaryFolder testProjectDir = new TemporaryFolder()
+  @Rule
+  final TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    File buildFile
+  File buildFile
 
-    def setupSpec() {
-        applicationName = 'Gradle Plugin Test'
-        s3BucketName = 'elasticbeanstalk-eu-central-1-000354356830'
-        s3Client = AmazonS3ClientBuilder.standard().withRegion('eu-central-1').build()
-        client = AWSElasticBeanstalkClientBuilder.standard()
-                .withRegion('eu-central-1')
-                .build()
-        client.createApplication(new CreateApplicationRequest()
-                .withApplicationName(applicationName))
-        createApplicationVersion('0.0.0')
-        createApplicationVersion('1.0.0-2-g4b03a14')
-        createApplicationVersion('1.0.2-20-g4b03a14')
-        createApplicationVersion('1.5.20-21-g4b03a14')
-        createApplicationVersion('20.10.1-5-g4b03a14')
-        createApplicationVersion('1.0.0')
-    }
+  def setupSpec() {
+    applicationName = 'Gradle Plugin Test'
+    s3BucketName = 'elasticbeanstalk-eu-central-1-000354356830'
+    s3Client = AmazonS3ClientBuilder.standard().withRegion('eu-central-1').build()
+    client = AWSElasticBeanstalkClientBuilder.standard()
+        .withRegion('eu-central-1')
+        .build()
+    client.createApplication(new CreateApplicationRequest()
+        .withApplicationName(applicationName))
+    createApplicationVersion('0.0.0')
+    createApplicationVersion('1.0.0-2-g4b03a14')
+    createApplicationVersion('1.0.2-20-g4b03a14')
+    createApplicationVersion('1.5.20-21-g4b03a14')
+    createApplicationVersion('20.10.1-5-g4b03a14')
+    createApplicationVersion('1.0.0')
+  }
 
-    def setup() {
-        testProjectDir.create()
-        buildFile = testProjectDir.newFile('build.gradle')
-    }
+  def setup() {
+    testProjectDir.create()
+    buildFile = testProjectDir.newFile('build.gradle')
+  }
 
-    def "should cleanup old application versions"() {
-        given:
-            buildFile << """
+  def "should cleanup old application versions"() {
+    given:
+    buildFile << """
         plugins {
           id 'de.jansauer.elasticbeanstalk'
         }
@@ -65,42 +65,43 @@ class CleanupVersionsTest extends Specification {
           applicationName = 'Gradle Plugin Test'
           versionToPreserve = 2
         }
-
     """
 
-        when:
-            def result = GradleRunner.create()
-                    .withProjectDir(testProjectDir.root)
-                    .withArguments('cleanupVersions', '-i')
-                    .withPluginClasspath()
-                    .build()
-            print result.output
+    when:
+    def result = GradleRunner.create()
+        .withProjectDir(testProjectDir.root)
+        .withArguments('cleanupVersions', '-i')
+        .withPluginClasspath()
+        .build()
+    print result.output
 
-        then:
-            result.task(':cleanupVersions').outcome == SUCCESS
+    then:
+    result.task(':cleanupVersions').outcome == SUCCESS
 
-        when:
-            def remainingVersions = client.describeApplicationVersions(new DescribeApplicationVersionsRequest()
-                    .withApplicationName(applicationName))
-                    .getApplicationVersions()
-        then:
-            remainingVersions.size() == 4
-            remainingVersions.collectNested({ it.versionLabel }) == ["1.0.0", "20.10.1-5-g4b03a14", "1.5.20-21-g4b03a14", "0.0.0"]
-    }
+    when:
+    def remainingVersions = client.describeApplicationVersions(new DescribeApplicationVersionsRequest()
+        .withApplicationName(applicationName))
+        .getApplicationVersions()
+    then:
+    remainingVersions.size() == 4
+    remainingVersions.collectNested({
+      it.versionLabel
+    }) == ['1.0.0', '20.10.1-5-g4b03a14', '1.5.20-21-g4b03a14', '0.0.0']
+  }
 
-    def cleanupSpec() {
-        client.deleteApplication(new DeleteApplicationRequest().withApplicationName(applicationName))
-    }
+  def cleanupSpec() {
+    client.deleteApplication(new DeleteApplicationRequest().withApplicationName(applicationName))
+  }
 
-    def createApplicationVersion(String version) {
-        s3Client.putObject(s3BucketName, version + '.jar', version as String)
-        client.createApplicationVersion(new CreateApplicationVersionRequest()
-                .withApplicationName(applicationName)
-                .withVersionLabel(version)
-                .withDescription("Test application version " + version)
-                .withSourceBundle(new S3Location()
-                .withS3Bucket(s3BucketName)
-                .withS3Key(version + '.jar'))
-                .withProcess(false));
-    }
+  def createApplicationVersion(String version) {
+    s3Client.putObject(s3BucketName, version + '.jar', version as String)
+    client.createApplicationVersion(new CreateApplicationVersionRequest()
+        .withApplicationName(applicationName)
+        .withVersionLabel(version)
+        .withDescription('Test application version ' + version)
+        .withSourceBundle(new S3Location()
+            .withS3Bucket(s3BucketName)
+            .withS3Key(version + '.jar'))
+        .withProcess(false))
+  }
 }


### PR DESCRIPTION
The S3 bucket name is no longer hard coded in the application version creation. It is now a shared variable.